### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/913/421166913.geojson
+++ b/data/421/166/913/421166913.geojson
@@ -647,6 +647,9 @@
     },
     "wof:country":"CD",
     "wof:created":1459008707,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b93164c227db1c3fae897949f99bb7ad",
     "wof:hierarchy":[
         {
@@ -657,7 +660,7 @@
         }
     ],
     "wof:id":421166913,
-    "wof:lastmodified":1566636370,
+    "wof:lastmodified":1582347485,
     "wof:name":"Kinshasa",
     "wof:parent_id":85669997,
     "wof:placetype":"locality",

--- a/data/421/196/249/421196249.geojson
+++ b/data/421/196/249/421196249.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"CD",
     "wof:created":1459009874,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"49af62f4b3b6e4e619b9364878139b5b",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":421196249,
-    "wof:lastmodified":1566636375,
+    "wof:lastmodified":1582347485,
     "wof:name":"Zongo",
     "wof:parent_id":85669975,
     "wof:placetype":"locality",

--- a/data/856/326/43/85632643.geojson
+++ b/data/856/326/43/85632643.geojson
@@ -1258,6 +1258,11 @@
     },
     "wof:country":"CD",
     "wof:country_alpha3":"COD",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"232bd92415de430d732dcb6207c8e3e0",
     "wof:hierarchy":[
         {
@@ -1276,7 +1281,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1566634158,
+    "wof:lastmodified":1582347454,
     "wof:name":"Democratic Republic of the Congo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/857/718/31/85771831.geojson
+++ b/data/857/718/31/85771831.geojson
@@ -137,6 +137,9 @@
         "qs_pg:id":1083553
     },
     "wof:country":"CD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec003a1ab89924c689c9bc59ef064a25",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566634155,
+    "wof:lastmodified":1582347453,
     "wof:name":"Kalina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/33/85771833.geojson
+++ b/data/857/718/33/85771833.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1115216
     },
     "wof:country":"CD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8afd1e6f5152e8b2aa09b24df6820737",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566634155,
+    "wof:lastmodified":1582347452,
     "wof:name":"L\u00e9o-Est",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/35/85771835.geojson
+++ b/data/857/718/35/85771835.geojson
@@ -78,6 +78,9 @@
         "qs:id":1167983
     },
     "wof:country":"CD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e9eb2529f40dfe516b7f06987101282",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379250,
+    "wof:lastmodified":1582347452,
     "wof:name":"Ndolo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/439/949/890439949.geojson
+++ b/data/890/439/949/890439949.geojson
@@ -316,6 +316,9 @@
     },
     "wof:country":"CD",
     "wof:created":1469052256,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ecc12cd5fb47c86c4a058d5a248e32f",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         }
     ],
     "wof:id":890439949,
-    "wof:lastmodified":1566636377,
+    "wof:lastmodified":1582347485,
     "wof:name":"Mbandaka",
     "wof:parent_id":1091679473,
     "wof:placetype":"locality",

--- a/data/890/440/099/890440099.geojson
+++ b/data/890/440/099/890440099.geojson
@@ -300,6 +300,9 @@
     },
     "wof:country":"CD",
     "wof:created":1469052262,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab56128efe5dcba82255ec4b78ae0bfd",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         }
     ],
     "wof:id":890440099,
-    "wof:lastmodified":1566636377,
+    "wof:lastmodified":1582347485,
     "wof:name":"Kalemie",
     "wof:parent_id":1091680307,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.