### PR TITLE
cd concordances, placetype local, and more

### DIFF
--- a/data/109/167/922/5/1091679225.geojson
+++ b/data/109/167/922/5/1091679225.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"CD.KN.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878838,
     "wof:geomhash":"7837152fd5db1845aa40f62a5c054df5",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1091679225,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886340,
     "wof:name":"Lukunga",
     "wof:parent_id":85669997,
     "wof:placetype":"county",

--- a/data/109/167/924/1/1091679241.geojson
+++ b/data/109/167/924/1/1091679241.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"CD.KN.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878839,
     "wof:geomhash":"03cbd3f05657d2c73baafe7e3cb128c4",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1091679241,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886291,
     "wof:name":"Funa",
     "wof:parent_id":85669997,
     "wof:placetype":"county",

--- a/data/109/167/925/1/1091679251.geojson
+++ b/data/109/167/925/1/1091679251.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"CD.KN.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878841,
     "wof:geomhash":"899c94616d66e6b96cc98892324763fa",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1091679251,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886351,
     "wof:name":"Mont Amba",
     "wof:parent_id":85669997,
     "wof:placetype":"county",

--- a/data/109/167/926/7/1091679267.geojson
+++ b/data/109/167/926/7/1091679267.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"CD.KN.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878843,
     "wof:geomhash":"6ed367701e5c6d9baa3562f9ca5eefc4",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1091679267,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886414,
     "wof:name":"Tshangu",
     "wof:parent_id":85669997,
     "wof:placetype":"county",

--- a/data/109/167/927/7/1091679277.geojson
+++ b/data/109/167/927/7/1091679277.geojson
@@ -185,6 +185,7 @@
     "wof:concordances":{
         "hasc:id":"CD.BC.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878844,
     "wof:geomhash":"72afc6405fb1d5d18db45d653dd46cbb",
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":1091679277,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886288,
     "wof:name":"Matadi",
     "wof:parent_id":85669993,
     "wof:placetype":"county",

--- a/data/109/167/927/9/1091679279.geojson
+++ b/data/109/167/927/9/1091679279.geojson
@@ -93,7 +93,7 @@
         }
     ],
     "wof:id":1091679279,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886288,
     "wof:name":"Boma",
     "wof:parent_id":85669993,
     "wof:placetype":"county",

--- a/data/109/167/930/3/1091679303.geojson
+++ b/data/109/167/930/3/1091679303.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1091679303,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886255,
     "wof:name":"Bas-Fleuve",
     "wof:parent_id":85669993,
     "wof:placetype":"county",

--- a/data/109/167/933/1/1091679331.geojson
+++ b/data/109/167/933/1/1091679331.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1091679331,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886273,
     "wof:name":"Cataractes",
     "wof:parent_id":85669993,
     "wof:placetype":"county",

--- a/data/109/167/935/1/1091679351.geojson
+++ b/data/109/167/935/1/1091679351.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1091679351,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886287,
     "wof:name":"Lukaya",
     "wof:parent_id":85669993,
     "wof:placetype":"county",

--- a/data/109/167/935/3/1091679353.geojson
+++ b/data/109/167/935/3/1091679353.geojson
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":1091679353,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Bandundu",
     "wof:parent_id":85669985,
     "wof:placetype":"county",

--- a/data/109/167/935/5/1091679355.geojson
+++ b/data/109/167/935/5/1091679355.geojson
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1091679355,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886288,
     "wof:name":"Mai-Ndombe",
     "wof:parent_id":85669985,
     "wof:placetype":"county",

--- a/data/109/167/938/5/1091679385.geojson
+++ b/data/109/167/938/5/1091679385.geojson
@@ -185,7 +185,7 @@
         }
     ],
     "wof:id":1091679385,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Kwilu",
     "wof:parent_id":85669985,
     "wof:placetype":"county",

--- a/data/109/167/940/3/1091679403.geojson
+++ b/data/109/167/940/3/1091679403.geojson
@@ -180,7 +180,7 @@
         }
     ],
     "wof:id":1091679403,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Kikwit",
     "wof:parent_id":85669985,
     "wof:placetype":"county",

--- a/data/109/167/942/9/1091679429.geojson
+++ b/data/109/167/942/9/1091679429.geojson
@@ -150,7 +150,7 @@
         }
     ],
     "wof:id":1091679429,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Kwango",
     "wof:parent_id":85669985,
     "wof:placetype":"county",

--- a/data/109/167/945/5/1091679455.geojson
+++ b/data/109/167/945/5/1091679455.geojson
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":1091679455,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Plateaux",
     "wof:parent_id":85669985,
     "wof:placetype":"county",

--- a/data/109/167/947/3/1091679473.geojson
+++ b/data/109/167/947/3/1091679473.geojson
@@ -179,6 +179,7 @@
     "wof:concordances":{
         "hasc:id":"CD.ET.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878861,
     "wof:geomhash":"5e28657e5c3d12b17891267b07c5e3c8",
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1091679473,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886287,
     "wof:name":"Mbandaka",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/953/9/1091679539.geojson
+++ b/data/109/167/953/9/1091679539.geojson
@@ -227,7 +227,7 @@
         }
     ],
     "wof:id":1091679539,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886287,
     "wof:name":"Equateur",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/955/9/1091679559.geojson
+++ b/data/109/167/955/9/1091679559.geojson
@@ -152,7 +152,7 @@
         }
     ],
     "wof:id":1091679559,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886287,
     "wof:name":"Sud-Ubangi",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/958/9/1091679589.geojson
+++ b/data/109/167/958/9/1091679589.geojson
@@ -121,7 +121,7 @@
         }
     ],
     "wof:id":1091679589,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Zongo",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/960/5/1091679605.geojson
+++ b/data/109/167/960/5/1091679605.geojson
@@ -155,7 +155,7 @@
         }
     ],
     "wof:id":1091679605,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886288,
     "wof:name":"Nord-Ubangi",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/964/7/1091679647.geojson
+++ b/data/109/167/964/7/1091679647.geojson
@@ -170,7 +170,7 @@
         }
     ],
     "wof:id":1091679647,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Mongala",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/964/9/1091679649.geojson
+++ b/data/109/167/964/9/1091679649.geojson
@@ -170,7 +170,7 @@
         }
     ],
     "wof:id":1091679649,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Tshuapa",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/965/3/1091679653.geojson
+++ b/data/109/167/965/3/1091679653.geojson
@@ -180,7 +180,7 @@
         }
     ],
     "wof:id":1091679653,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Gbadolite",
     "wof:parent_id":85669975,
     "wof:placetype":"county",

--- a/data/109/167/965/5/1091679655.geojson
+++ b/data/109/167/965/5/1091679655.geojson
@@ -218,6 +218,7 @@
     "wof:concordances":{
         "hasc:id":"CD.TO.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878877,
     "wof:geomhash":"a158848f3c2f690871673156d7412c5f",
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":1091679655,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886287,
     "wof:name":"Kisangani",
     "wof:parent_id":85669979,
     "wof:placetype":"county",

--- a/data/109/167/967/9/1091679679.geojson
+++ b/data/109/167/967/9/1091679679.geojson
@@ -153,6 +153,7 @@
         "hasc:id":"CD.TO.TS",
         "wd:id":"Q630900"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878879,
     "wof:geomhash":"0799d46dd81fba98f793420ca92979e8",
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1091679679,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886288,
     "wof:name":"Tshopo",
     "wof:parent_id":85669979,
     "wof:placetype":"county",

--- a/data/109/167/972/1/1091679721.geojson
+++ b/data/109/167/972/1/1091679721.geojson
@@ -155,7 +155,7 @@
         }
     ],
     "wof:id":1091679721,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886289,
     "wof:name":"Bas-Uele",
     "wof:parent_id":85669979,
     "wof:placetype":"county",

--- a/data/109/167/975/5/1091679755.geojson
+++ b/data/109/167/975/5/1091679755.geojson
@@ -161,7 +161,7 @@
         }
     ],
     "wof:id":1091679755,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886289,
     "wof:name":"Haut-Uele",
     "wof:parent_id":85669979,
     "wof:placetype":"county",

--- a/data/109/167/979/7/1091679797.geojson
+++ b/data/109/167/979/7/1091679797.geojson
@@ -153,7 +153,7 @@
         }
     ],
     "wof:id":1091679797,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Ituri",
     "wof:parent_id":85669979,
     "wof:placetype":"county",

--- a/data/109/167/983/7/1091679837.geojson
+++ b/data/109/167/983/7/1091679837.geojson
@@ -186,6 +186,7 @@
     "wof:concordances":{
         "hasc:id":"CD.NK.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878885,
     "wof:geomhash":"830e92910d531017572c4f97fab0023f",
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":1091679837,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886287,
     "wof:name":"Goma",
     "wof:parent_id":85670021,
     "wof:placetype":"county",

--- a/data/109/167/986/3/1091679863.geojson
+++ b/data/109/167/986/3/1091679863.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091679863,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Nord-Kivu",
     "wof:parent_id":85670021,
     "wof:placetype":"county",

--- a/data/109/167/990/7/1091679907.geojson
+++ b/data/109/167/990/7/1091679907.geojson
@@ -138,6 +138,7 @@
     "wof:concordances":{
         "hasc:id":"CD.NK.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878888,
     "wof:geomhash":"c71f8da2ed24f3fa9952df268e6bba03",
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091679907,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Beni",
     "wof:parent_id":85670021,
     "wof:placetype":"county",

--- a/data/109/167/994/1/1091679941.geojson
+++ b/data/109/167/994/1/1091679941.geojson
@@ -130,7 +130,7 @@
         }
     ],
     "wof:id":1091679941,
-    "wof:lastmodified":1694498107,
+    "wof:lastmodified":1695886780,
     "wof:name":"Butembo",
     "wof:parent_id":85670021,
     "wof:placetype":"county",

--- a/data/109/167/996/7/1091679967.geojson
+++ b/data/109/167/996/7/1091679967.geojson
@@ -198,7 +198,7 @@
         }
     ],
     "wof:id":1091679967,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886287,
     "wof:name":"Bukavu",
     "wof:parent_id":85670003,
     "wof:placetype":"county",

--- a/data/109/168/000/1/1091680001.geojson
+++ b/data/109/168/000/1/1091680001.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1091680001,
-    "wof:lastmodified":1694498105,
+    "wof:lastmodified":1695886777,
     "wof:name":"Sud-Kivu",
     "wof:parent_id":85670003,
     "wof:placetype":"county",

--- a/data/109/168/007/1/1091680071.geojson
+++ b/data/109/168/007/1/1091680071.geojson
@@ -177,6 +177,7 @@
     "wof:concordances":{
         "hasc:id":"CD.MN.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878895,
     "wof:geomhash":"56bcc43174394e020aaba21f25ce4e37",
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":1091680071,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886778,
     "wof:name":"Kindu",
     "wof:parent_id":85670007,
     "wof:placetype":"county",

--- a/data/109/168/009/3/1091680093.geojson
+++ b/data/109/168/009/3/1091680093.geojson
@@ -171,7 +171,7 @@
         }
     ],
     "wof:id":1091680093,
-    "wof:lastmodified":1694497935,
+    "wof:lastmodified":1695886403,
     "wof:name":"Maniema",
     "wof:parent_id":85670007,
     "wof:placetype":"county",

--- a/data/109/168/014/1/1091680141.geojson
+++ b/data/109/168/014/1/1091680141.geojson
@@ -218,6 +218,7 @@
     "wof:concordances":{
         "hasc:id":"CD.HK.LB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878898,
     "wof:geomhash":"208b67e2fae878e8535172926044bf64",
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":1091680141,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886284,
     "wof:name":"Lubumbashi",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/018/1/1091680181.geojson
+++ b/data/109/168/018/1/1091680181.geojson
@@ -162,6 +162,7 @@
     "wof:concordances":{
         "hasc:id":"CD.HK.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878900,
     "wof:geomhash":"6de3070804c816b51779fb7471057b16",
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1091680181,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886285,
     "wof:name":"Likasi",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/019/7/1091680197.geojson
+++ b/data/109/168/019/7/1091680197.geojson
@@ -174,7 +174,7 @@
         }
     ],
     "wof:id":1091680197,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886285,
     "wof:name":"Kolwezi",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/023/9/1091680239.geojson
+++ b/data/109/168/023/9/1091680239.geojson
@@ -118,7 +118,7 @@
         }
     ],
     "wof:id":1091680239,
-    "wof:lastmodified":1694498105,
+    "wof:lastmodified":1695886777,
     "wof:name":"Lualaba",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/027/7/1091680277.geojson
+++ b/data/109/168/027/7/1091680277.geojson
@@ -171,7 +171,7 @@
         }
     ],
     "wof:id":1091680277,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886285,
     "wof:name":"Haut-Lomami",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/030/7/1091680307.geojson
+++ b/data/109/168/030/7/1091680307.geojson
@@ -166,7 +166,7 @@
         }
     ],
     "wof:id":1091680307,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886284,
     "wof:name":"Tanganyka",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/033/3/1091680333.geojson
+++ b/data/109/168/033/3/1091680333.geojson
@@ -177,7 +177,7 @@
         }
     ],
     "wof:id":1091680333,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886286,
     "wof:name":"Haut-Katanga",
     "wof:parent_id":85670015,
     "wof:placetype":"county",

--- a/data/109/168/036/7/1091680367.geojson
+++ b/data/109/168/036/7/1091680367.geojson
@@ -198,7 +198,7 @@
         }
     ],
     "wof:id":1091680367,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886458,
     "wof:name":"Mbuji-Mayi",
     "wof:parent_id":85670011,
     "wof:placetype":"county",

--- a/data/109/168/037/3/1091680373.geojson
+++ b/data/109/168/037/3/1091680373.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"CD.KO.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878911,
     "wof:geomhash":"8b1fc21a09c6de6d2da13f23c0faa1ac",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1091680373,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886414,
     "wof:name":"Tshilenge",
     "wof:parent_id":85670011,
     "wof:placetype":"county",

--- a/data/109/168/039/9/1091680399.geojson
+++ b/data/109/168/039/9/1091680399.geojson
@@ -171,7 +171,7 @@
         }
     ],
     "wof:id":1091680399,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Sankuru",
     "wof:parent_id":85670011,
     "wof:placetype":"county",

--- a/data/109/168/043/5/1091680435.geojson
+++ b/data/109/168/043/5/1091680435.geojson
@@ -170,6 +170,7 @@
         "hasc:id":"CD.LM.KB",
         "wd:id":"Q241886"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878914,
     "wof:geomhash":"74e76823440b874c8216f8565b372b11",
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1091680435,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Kabinda",
     "wof:parent_id":85670011,
     "wof:placetype":"county",

--- a/data/109/168/045/7/1091680457.geojson
+++ b/data/109/168/045/7/1091680457.geojson
@@ -114,6 +114,7 @@
     "wof:concordances":{
         "hasc:id":"CD.LM.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878916,
     "wof:geomhash":"a26f8aafd5f99180b77eb4be2d4cf208",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1091680457,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Mwene-Ditu",
     "wof:parent_id":85670011,
     "wof:placetype":"county",

--- a/data/109/168/048/7/1091680487.geojson
+++ b/data/109/168/048/7/1091680487.geojson
@@ -191,6 +191,7 @@
     "wof:concordances":{
         "hasc:id":"CD.LL.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CD",
     "wof:created":1473878917,
     "wof:geomhash":"dca8a16233ed786ff97e0d09fa4a22e2",
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":1091680487,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886284,
     "wof:name":"Kananga",
     "wof:parent_id":85669989,
     "wof:placetype":"county",

--- a/data/109/168/051/7/1091680517.geojson
+++ b/data/109/168/051/7/1091680517.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1091680517,
-    "wof:lastmodified":1694497837,
+    "wof:lastmodified":1695886286,
     "wof:name":"Lulua",
     "wof:parent_id":85669989,
     "wof:placetype":"county",

--- a/data/109/168/054/3/1091680543.geojson
+++ b/data/109/168/054/3/1091680543.geojson
@@ -133,7 +133,7 @@
         }
     ],
     "wof:id":1091680543,
-    "wof:lastmodified":1694498106,
+    "wof:lastmodified":1695886779,
     "wof:name":"Kasai",
     "wof:parent_id":85669989,
     "wof:placetype":"county",

--- a/data/856/326/43/85632643.geojson
+++ b/data/856/326/43/85632643.geojson
@@ -1433,6 +1433,7 @@
         "hasc:id":"CD",
         "icao:code":"9Q",
         "ioc:id":"COD",
+        "iso:code":"CD",
         "itu:id":"COD",
         "loc:id":"n80061022",
         "m49:code":"180",
@@ -1446,6 +1447,7 @@
         "wk:page":"Democratic Republic of the Congo",
         "wmo:id":"ZR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:country_alpha3":"COD",
     "wof:geom_alt":[
@@ -1471,7 +1473,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694639533,
+    "wof:lastmodified":1695881190,
     "wof:name":"Democratic Republic of the Congo",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/699/75/85669975.geojson
+++ b/data/856/699/75/85669975.geojson
@@ -256,11 +256,13 @@
         "gn:id":216661,
         "gp:id":2344978,
         "hasc:id":"CD.EQ",
+        "iso:code":"CD-EQ",
         "qs_pg:id":423620,
         "unlc:id":"CD-EQ",
         "wd:id":"Q139626",
         "wk:page":"\u00c9quateur (former province)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"47a7805af5b2abb23107062c875d9aaf",
     "wof:hierarchy":[
@@ -281,7 +283,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884501,
     "wof:name":"\u00c9quateur",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/699/79/85669979.geojson
+++ b/data/856/699/79/85669979.geojson
@@ -293,11 +293,13 @@
         "gn:id":216139,
         "gp:id":2344985,
         "hasc:id":"CD.HC",
+        "iso:code":"CD-OR",
         "qs_pg:id":219525,
         "unlc:id":"CD-OR",
         "wd:id":"Q831370",
         "wk:page":"Orientale Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"62104184264be324b502833c9c06734d",
     "wof:hierarchy":[
@@ -318,7 +320,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884883,
     "wof:name":"Orientale",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/699/85/85669985.geojson
+++ b/data/856/699/85/85669985.geojson
@@ -280,11 +280,13 @@
         "gn:id":2317396,
         "gp:id":2344977,
         "hasc:id":"CD.BN",
+        "iso:code":"CD-BN",
         "qs_pg:id":423615,
         "unlc:id":"CD-BN",
         "wd:id":"Q671442",
         "wk:page":"Bandundu Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"18db0624d312016ea2d648bcae08bbc4",
     "wof:hierarchy":[
@@ -305,7 +307,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884883,
     "wof:name":"Bandundu",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/699/89/85669989.geojson
+++ b/data/856/699/89/85669989.geojson
@@ -270,11 +270,13 @@
         "gn:id":214139,
         "gp:id":2344979,
         "hasc:id":"CD.KC",
+        "iso:code":"CD-KC",
         "qs_pg:id":318363,
         "unlc:id":"CD-KW",
         "wd:id":"Q130576",
         "wk:page":"Kasai-Occidental"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"751c618202f4312c690b4977eda72f8a",
     "wof:hierarchy":[
@@ -295,7 +297,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694639831,
+    "wof:lastmodified":1695884326,
     "wof:name":"Kasa\u00ef-Occidental",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/699/93/85669993.geojson
+++ b/data/856/699/93/85669993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.435272,
-    "geom:area_square_m":54609392669.683418,
+    "geom:area_square_m":54609396986.918365,
     "geom:bbox":"12.210555,-6.051928,16.278676,-4.277102",
     "geom:latitude":-5.277159,
     "geom:longitude":14.312602,
@@ -318,14 +318,16 @@
         "gn:id":2317277,
         "gp:id":2344984,
         "hasc:id":"CD.BC",
+        "iso:code":"CD-BC",
         "iso:id":"CD-BC",
         "qs_pg:id":229366,
         "unlc:id":"CD-BC",
         "wd:id":"Q130588",
         "wk:page":"Kongo Central"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
-    "wof:geomhash":"bcea9d8395ba92360dfce455edc387fc",
+    "wof:geomhash":"5922b9f76725b28bba4300cd5c44b181",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -344,7 +346,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1690865796,
+    "wof:lastmodified":1695884326,
     "wof:name":"Bas-Congo",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/699/97/85669997.geojson
+++ b/data/856/699/97/85669997.geojson
@@ -157,11 +157,13 @@
         "gn:id":2314300,
         "gp:id":2344982,
         "hasc:id":"CD.KN",
+        "iso:code":"CD-KN",
         "qs_pg:id":423622,
         "unlc:id":"CD-KN",
         "wd:id":"Q3091458",
         "wk:page":"Kinshasa (commune)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"f579d950728252ee052bf1fbb99f9b4f",
     "wof:hierarchy":[
@@ -182,7 +184,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884326,
     "wof:name":"Kinshasa City",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/700/03/85670003.geojson
+++ b/data/856/700/03/85670003.geojson
@@ -305,11 +305,13 @@
         "gn:id":205413,
         "gp:id":20069829,
         "hasc:id":"CD.KV",
+        "iso:code":"CD-SK",
         "qs_pg:id":1117316,
         "unlc:id":"CD-SK",
         "wd:id":"Q488326",
         "wk:page":"South Kivu"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"de7ff8aa26338900dc3ef83103bdcf57",
     "wof:hierarchy":[
@@ -330,7 +332,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694493259,
+    "wof:lastmodified":1695884883,
     "wof:name":"Sud-Kivu",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/700/07/85670007.geojson
+++ b/data/856/700/07/85670007.geojson
@@ -326,11 +326,13 @@
         "gn:id":209610,
         "gp:id":20069831,
         "hasc:id":"CD.MN",
+        "iso:code":"CD-MA",
         "qs_pg:id":236536,
         "unlc:id":"CD-MA",
         "wd:id":"Q130566",
         "wk:page":"Maniema"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1091680093
     ],
@@ -354,7 +356,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694493163,
+    "wof:lastmodified":1695884464,
     "wof:name":"Maniema",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/700/11/85670011.geojson
+++ b/data/856/700/11/85670011.geojson
@@ -269,11 +269,13 @@
         "gn:id":214138,
         "gp:id":2344980,
         "hasc:id":"CD.KR",
+        "iso:code":"CD-KE",
         "qs_pg:id":423621,
         "unlc:id":"CD-KE",
         "wd:id":"Q80953",
         "wk:page":"Kasai-Oriental (former province)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"12671daa4ad367ad0fe5c8a2a4c9f3fc",
     "wof:hierarchy":[
@@ -294,7 +296,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884501,
     "wof:name":"Kasa\u00ef-Oriental",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/700/15/85670015.geojson
+++ b/data/856/700/15/85670015.geojson
@@ -338,10 +338,12 @@
         "gn:id":205703,
         "gp:id":2344981,
         "hasc:id":"CD.KT",
+        "iso:code":"CD-HK",
         "qs_pg:id":1114940,
         "unlc:id":"CD-KA",
         "wd:id":"Q217242"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"7019f0bdb2a792978e0150fe0a3e829f",
     "wof:hierarchy":[
@@ -362,7 +364,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694493259,
+    "wof:lastmodified":1695884883,
     "wof:name":"Katanga",
     "wof:parent_id":85632643,
     "wof:placetype":"region",

--- a/data/856/700/21/85670021.geojson
+++ b/data/856/700/21/85670021.geojson
@@ -335,11 +335,13 @@
         "gn:id":206938,
         "gp:id":20069830,
         "hasc:id":"CD.NK",
+        "iso:code":"CD-NK",
         "qs_pg:id":1295984,
         "unlc:id":"CD-NK",
         "wd:id":"Q130625",
         "wk:page":"North Kivu"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CD",
     "wof:geomhash":"dbd9257305c2f0e92dee840c75308d83",
     "wof:hierarchy":[
@@ -360,7 +362,7 @@
         "lin",
         "kon"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884883,
     "wof:name":"Nord-Kivu",
     "wof:parent_id":85632643,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.